### PR TITLE
Refactoring

### DIFF
--- a/v-wallet-selector/v-wallet-selector.js
+++ b/v-wallet-selector/v-wallet-selector.js
@@ -70,16 +70,10 @@ export default class VWalletSelector extends MixinRedux(XElement) {
                 mapStateToProps(state) {
                     let wallets = walletsArray$(state)
 
-                    /*if (!wallets) {
-                        return {
-                            wallets: [],
-                            activeWalletId: 'LEGACY',
-                        }
-                    }*/
-
+                    // FIXME why do we need this?
                     wallets = wallets.map(wallet => {
                         return Object.assign({}, wallet, {
-                            accounts: new Map(new Array(wallet.numberAccounts).fill(0).map((_, i) => [i.toString(), 'dummy'])),
+                            accounts: new Map(wallet.accounts.map((account) => [account.address, account])),
                             contracts: [],
                         })
                     })

--- a/x-accounts/x-account-modal.js
+++ b/x-accounts/x-account-modal.js
@@ -5,7 +5,7 @@ import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
 import ValidationUtils from '/libraries/secure-utils/validation-utils/validation-utils.js';
 import { dashToSpace } from '/libraries/nimiq-utils/parameter-encoding/parameter-encoding.js';
 import XPopupMenu from '/elements/x-popup-menu/x-popup-menu.js';
-import AccountType from '/libraries/account-manager/account-type.js';
+import AccountType from '/apps/safe/src/lib/account-type.js';
 import VQrCodeOverlay from '/elements/v-qr-code-overlay/v-qr-code-overlay.js';
 
 export default class XAccountModal extends MixinModal(XAccount) {

--- a/x-accounts/x-accounts.js
+++ b/x-accounts/x-accounts.js
@@ -24,16 +24,11 @@ export default class XAccounts extends MixinRedux(XElement) {
 
     static mapStateToProps(state) {
         return {
-            keyguardReady: state.connection.keyguard,
             activeWalletId: activeWalletId$(state),
         }
     }
 
     _onPropertiesChanged(changes) {
-        if (changes.keyguardReady) {
-            this.$('.add').classList.remove('waiting');
-        }
-
         if (changes.activeWalletId) {
             this.$('x-popup-menu').classList.toggle('hidden', this.properties.activeWalletId === 'LEGACY');
         }

--- a/x-send-transaction/x-send-transaction.js
+++ b/x-send-transaction/x-send-transaction.js
@@ -10,7 +10,7 @@ import networkClient from '/apps/safe/src/network-client.js';
 import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
 // import XPopupMenu from '/elements/x-popup-menu/x-popup-menu.js';
 import Config from '/libraries/secure-utils/config/config.js';
-import AccountType from '../../libraries/account-manager/account-type.js';
+import AccountType from '/apps/safe/src/lib/account-type.js';
 import VContactListModal from '/elements/v-contact-list/v-contact-list-modal.js';
 import ValidationUtils from '/libraries/secure-utils/validation-utils/validation-utils.js';
 import { parseRequestLink } from '/libraries/nimiq-utils/request-link-encoding/request-link-encoding.js';


### PR DESCRIPTION
- refactor legacy wallet handling (generally move logic to reducers and selectors)
- add `removeAccount()` (for later use with hide account feature)
- change AccountType path (now included in Safe repo)
- removes upgrade actions

Plays along with https://github.com/nimiq/safe/pull/79