### PR TITLE
Hide selected address in dropdown

### DIFF
--- a/x-accounts/x-accounts-dropdown.js
+++ b/x-accounts/x-accounts-dropdown.js
@@ -3,6 +3,8 @@ import XExpandable from '../x-expandable/x-expandable.js';
 import XAccount from './x-account.js';
 import XAccountsList from './x-accounts-list.js';
 import MixinRedux from '/secure-elements/mixin-redux/mixin-redux.js';
+import AccountType from '../../apps/safe/src/lib/account-type.js';
+import { activeAccounts$ } from '../../apps/safe/src/selectors/account$.js';
 
 export default class XAccountsDropdown extends MixinRedux(XElement) {
 
@@ -38,7 +40,7 @@ export default class XAccountsDropdown extends MixinRedux(XElement) {
 
     static mapStateToProps(state) {
         return {
-            accounts: state.wallets.accounts,
+            accounts: activeAccounts$(state),
             hasContent: state.wallets.hasContent,
             loading: state.wallets.loading
         };
@@ -54,7 +56,7 @@ export default class XAccountsDropdown extends MixinRedux(XElement) {
 
         !this._isDisabled && this.$expandable.enable();
 
-        if (changes.accounts && !this.selectedAccount) {
+        if (changes.accounts) {
             this.selectDefaultAccount();
         }
     }
@@ -66,7 +68,7 @@ export default class XAccountsDropdown extends MixinRedux(XElement) {
         let account;
         do {
             account = accounts.next().value;
-        } while (account === 4) // Do not auto-select vesting accounts
+        } while (account === AccountType.VESTING || account === AccountType.HTLC) // Do not auto-select contracts
         this.selectedAccount = account;
     }
 
@@ -93,6 +95,8 @@ export default class XAccountsDropdown extends MixinRedux(XElement) {
         this.$account.account = account;
         this.$input.value = account.address;
         this.fire('x-account-selected', account.address);
+        // hide selected account 
+        this.$accountsList.selectedAccount = account.address;
     }
 
     _showStatusMessage() {
@@ -111,6 +115,8 @@ export default class XAccountsDropdown extends MixinRedux(XElement) {
         this.$account.setProperties(account);
         this.$input.value = account.address;
         this.$expandable.collapse();
+        // hide selected account 
+        this.$accountsList.selectedAccount = account.address;
     }
 
     disable() {

--- a/x-accounts/x-accounts-list.js
+++ b/x-accounts/x-accounts-list.js
@@ -42,6 +42,10 @@ export default class XAccountsList extends MixinRedux(XElement) {
                 } else if (!$account) {
                     // new entry
                     this._addAccountEntry(account);
+                    // hide if selected
+                    if (this._selectedAccount === address) {
+                        this._accountEntries.get(address).$el.classList.add('display-none');
+                    }
                 }
             }
         }
@@ -51,6 +55,14 @@ export default class XAccountsList extends MixinRedux(XElement) {
             const $noContent = XNoAccounts.createElement();
             this.$el.appendChild($noContent.$el);
         }
+    }
+
+    set selectedAccount(address) {
+        if (this._selectedAccount) {
+            this._accountEntries.get(this._selectedAccount).$el.classList.remove('display-none');
+        }
+        this._accountEntries.get(address).$el.classList.add('display-none');
+        this._selectedAccount = address;
     }
 
     /**


### PR DESCRIPTION
The already selected address should not appear in the dropdown. This PR fixes that.
Moreover, only addresses of the active wallet are now considered as default address. (They already don't appear  in the dropdown.)
HTLC contracts are filtered out, too.