### PR TITLE
Some Send Transaction fixes for Safe

### DIFF
--- a/x-accounts/x-accounts-dropdown.css
+++ b/x-accounts/x-accounts-dropdown.css
@@ -11,10 +11,6 @@ x-accounts-dropdown x-expandable:not([disabled]) [status-message] {
     display: none;
 }
 
-x-accounts-dropdown x-expandable[disabled] x-account {
-    opacity: 0.7;
-}
-
 x-accounts-dropdown [status-message]:not(:empty) {
     margin: 20px !important;
 }

--- a/x-accounts/x-accounts-dropdown.js
+++ b/x-accounts/x-accounts-dropdown.js
@@ -34,7 +34,6 @@ export default class XAccountsDropdown extends MixinRedux(XElement) {
             this.$input.setAttribute('name', this.attributes.name);
         }
         this.$account.addEventListener('x-account-selected', e => e.stopPropagation());
-        this._isDisabled = false;
         super.onCreate();
     }
 
@@ -49,12 +48,14 @@ export default class XAccountsDropdown extends MixinRedux(XElement) {
     _onPropertiesChanged(changes) {
         if (changes.loading === true || changes.hasContent === false
             || this.properties.accounts.size === 0) {
-            this.$expandable.disable();
             this._showStatusMessage();
-            return;
         }
 
-        !this._isDisabled && this.$expandable.enable();
+        if (this.properties.accounts.size <= 1) {
+            this.disable();
+        } else {
+            this.enable();
+        }
 
         if (changes.accounts) {
             this.selectDefaultAccount();

--- a/x-expandable/x-expandable.css
+++ b/x-expandable/x-expandable.css
@@ -38,6 +38,11 @@ x-expandable [expandable-trigger] {
     }
 }
 
+x-expandable[disabled] {
+    pointer-events: none;
+    box-shadow: none;
+}
+
 x-expandable[disabled] [expandable-trigger] {
     padding-right: 0;
 }

--- a/x-send-transaction/x-send-transaction-modal.js
+++ b/x-send-transaction/x-send-transaction-modal.js
@@ -12,8 +12,6 @@ export default class XSendTransactionModal extends MixinModal(XSendTransaction) 
     /* mode: 'sender'|'recipient'|'contact'|'vesting'|'scan' */
     onShow(address, mode, amount, message, freeze) {
 
-        this.clear(mode === 'contact');
-
         this.$amountInput.maxDecimals = document.body.classList.contains('setting-show-all-decimals') ? 5 : 2;
 
         if (address && mode === 'sender') {

--- a/x-send-transaction/x-send-transaction-offline-modal.js
+++ b/x-send-transaction/x-send-transaction-offline-modal.js
@@ -40,7 +40,7 @@ export default class XSendTransactionOfflineModal extends MixinModal(XElement) {
             this._txString = tx;
         } else {
             const clonedTx = Object.assign({}, tx, {});
-            clonedTx.senderPubKey = [...tx.senderPubKey];
+            clonedTx.signerPublicKey = [...tx.signerPublicKey];
             clonedTx.signature = [...tx.signature];
 
             this._txString = JSON.stringify(clonedTx).replace(/,"/g, ', "');

--- a/x-send-transaction/x-send-transaction.js
+++ b/x-send-transaction/x-send-transaction.js
@@ -100,8 +100,6 @@ export default class XSendTransaction extends MixinRedux(XElement) {
 
         this._errorElements = {};
 
-        this.clear();
-
         super.onCreate();
     }
 
@@ -159,16 +157,14 @@ export default class XSendTransaction extends MixinRedux(XElement) {
         this.fire('x-send-transaction', tx);
     }
 
-    clear(isFromContactList) {
-        if (!isFromContactList) this.$addressInput.value = '';
+    clear() {
+        this.$addressInput.value = '';
         this._isSetMax = false;
         this.$amountInput.value = '';
         this.$extraDataInput.value = '';
         this.$feeInput.reset();
         this.$form.querySelector('input[name="validityStartHeight"]').value = '';
         this.$expandable.collapse();
-        this.$accountsDropdown.selectDefaultAccount();
-        this.$accountsDropdown.enable();
         this.loading = false;
         this.fire('x-send-transaction-cleared');
     }
@@ -183,7 +179,7 @@ export default class XSendTransaction extends MixinRedux(XElement) {
 
     set loading(isLoading) {
         this._isLoading = !!isLoading;
-        this.$button.textContent = this._isLoading ? 'Loading' : 'Send';
+        this.$button.textContent = this._isLoading ? 'Sending...' : 'Send';
         this.setButton();
     }
 


### PR DESCRIPTION
- Replace sender by signer in offline tx modal (fixes bug)
- Reset tx modal only after sending. (https://github.com/nimiq/safe/pull/96) Keep it when the user just closes it or goes to contact list and back.
- Wording: "loading" => "sending..." in send transaction modal
- Disable dropdown with 1 account and change disabled dropdown style (no box-shadow, no decreased opacity, not clickable) Solves #28 